### PR TITLE
Implement simulation mode for local development

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,23 +1,37 @@
 # stdlib
 import logging
+import argparse
 
 # 3p
+import datadog
 from dotenv import load_dotenv
-from datadog import initialize
 from json_log_formatter import VerboseJSONFormatter
 
 load_dotenv()
-initialize(statsd_disable_buffering=False)
 
 # project
 from matrix.app import App
 
 
-logging.basicConfig(level=logging.INFO)
-handler = logging.FileHandler(filename="/var/log/matrix2.log")
-handler.setFormatter(VerboseJSONFormatter())
-# Add our handler to the root logger
-logging.root.addHandler(handler)
+parser = argparse.ArgumentParser(
+    prog="matrix2",
+    description="LED matrix display driver",
+)
 
-app = App()
+parser.add_argument("--simulate", action="store_true")
+parser.add_argument("--logfile", default="/var/log/matrix2.log")
+
+args = parser.parse_args()
+
+logging.basicConfig(level=logging.INFO)
+
+if not args.simulate:
+    datadog.initialize(statsd_disable_buffering=False)
+
+    handler = logging.FileHandler(filename=args.logfile)
+    handler.setFormatter(VerboseJSONFormatter())
+    # Add our handler to the root logger
+    logging.root.addHandler(handler)
+
+app = App(simulation=args.simulate)
 app.run()

--- a/matrix/app.py
+++ b/matrix/app.py
@@ -44,11 +44,14 @@ class App:
             ModeType.MENU: Menu(self.change_mode),
             ModeType.SCREENS: Screens(self.change_mode, screens),
             ModeType.OFF: Off(self.change_mode),
-            ModeType.BRIGHTNESS: Brightness(self.change_mode, hardware=self.hardware),
         }
 
+        if self.hardware is not None:
+            self.modes[ModeType.BRIGHTNESS] = Brightness(
+                self.change_mode, hardware=self.hardware
+            )
         if sys.platform == "linux":
-            self.modes.append(Network(self.change_mode))
+            self.modes[ModeType.NETWORK] = Network(self.change_mode)
 
         self.active_mode: ModeType = ModeType.MAIN
 

--- a/matrix/app.py
+++ b/matrix/app.py
@@ -47,9 +47,11 @@ class App:
         }
 
         if self.hardware is not None:
-            self.modes[ModeType.BRIGHTNESS] = Brightness(
-                self.change_mode, hardware=self.hardware
-            )
+            self.modes[ModeType.BRIGHTNESS] = Brightness(self.change_mode, hardware=self.hardware)
+            self.hardware.dial.when_rotated_clockwise = self.handle_rotation_clockwise
+            self.hardware.dial.when_rotated_counter_clockwise = self.handle_rotation_counterclockwise
+            self.hardware.button.when_pressed = self.handle_press
+
         if sys.platform == "linux":
             self.modes[ModeType.NETWORK] = Network(self.change_mode)
 
@@ -61,13 +63,6 @@ class App:
             on_rotation_counterclockwise=self.handle_rotation_counterclockwise,
             on_press=self.handle_press,
         )
-
-        if self.hardware is not None:
-            self.hardware.dial.when_rotated_clockwise = self.handle_rotation_clockwise
-            self.hardware.dial.when_rotated_counter_clockwise = (
-                self.handle_rotation_counterclockwise
-            )
-            self.hardware.button.when_pressed = self.handle_press
 
         self.signal_update = threading.Event()
 

--- a/matrix/app.py
+++ b/matrix/app.py
@@ -1,6 +1,7 @@
 # stdlib
 import threading
 import logging
+import sys
 
 # project
 from matrix.modes.screens import Screens
@@ -10,7 +11,6 @@ from matrix.screens.screen import Screen
 from matrix.screens.spotify import Spotify
 from matrix.screens.weather import Weather
 from matrix.web_ui import WebUI
-from matrix.utils.hardware import Hardware
 from matrix.utils.no_connection import get_image_no_connection
 
 from matrix.modes.mode import ModeType, BaseMode
@@ -25,8 +25,14 @@ logger = logging.getLogger(__name__)
 
 
 class App:
-    def __init__(self) -> None:
-        self.hardware = Hardware()
+    def __init__(self, *, simulation: bool = False) -> None:
+        if simulation:
+            self.hardware = None
+        else:
+            from matrix.utils.hardware import Hardware
+
+            self.hardware = Hardware()
+
         screens: list[Screen] = [
             MBTA(),
             Spotify(),
@@ -39,19 +45,26 @@ class App:
             ModeType.SCREENS: Screens(self.change_mode, screens),
             ModeType.OFF: Off(self.change_mode),
             ModeType.BRIGHTNESS: Brightness(self.change_mode, hardware=self.hardware),
-            ModeType.NETWORK: Network(self.change_mode),
         }
+
+        if sys.platform == "linux":
+            self.modes.append(Network(self.change_mode))
+
         self.active_mode: ModeType = ModeType.MAIN
 
         self.ui = WebUI(
+            port=8080 if simulation else 80,
             on_rotation_clockwise=self.handle_rotation_clockwise,
             on_rotation_counterclockwise=self.handle_rotation_counterclockwise,
             on_press=self.handle_press,
         )
 
-        self.hardware.dial.when_rotated_clockwise = self.handle_rotation_clockwise
-        self.hardware.dial.when_rotated_counter_clockwise = self.handle_rotation_counterclockwise
-        self.hardware.button.when_pressed = self.handle_press
+        if self.hardware is not None:
+            self.hardware.dial.when_rotated_clockwise = self.handle_rotation_clockwise
+            self.hardware.dial.when_rotated_counter_clockwise = (
+                self.handle_rotation_counterclockwise
+            )
+            self.hardware.button.when_pressed = self.handle_press
 
         self.signal_update = threading.Event()
 
@@ -82,9 +95,11 @@ class App:
 
                 if image != prev_image:  # Only send the image if it's different
                     self.ui.send_frame(image)
-                    self.hardware.matrix.SetImage(image.convert("RGB"))
+                    if self.hardware is not None:
+                        self.hardware.matrix.SetImage(image.convert("RGB"))
                     prev_image = image
                 if self.signal_update.wait(timeout=1):
                     self.signal_update.clear()
         finally:
-            self.hardware.matrix.Clear()
+            if self.hardware is not None:
+                self.hardware.matrix.Clear()

--- a/matrix/modes/brightness.py
+++ b/matrix/modes/brightness.py
@@ -12,12 +12,9 @@ BRIGHTNESS_STEP = 10
 
 
 class Brightness(BaseMode):
-    def __init__(self, change_mode: ChangeMode, *, hardware: "Hardware | None"):
+    def __init__(self, change_mode: ChangeMode, *, hardware: "Hardware"):
         super().__init__(change_mode)
-        if hardware:
-            self.matrix = hardware.matrix
-        else:
-            self.matrix = None
+        self.matrix = hardware.matrix
 
     def handle_encoder_push(self):
         self.change_mode(ModeType.MAIN)

--- a/matrix/modes/brightness.py
+++ b/matrix/modes/brightness.py
@@ -1,16 +1,23 @@
+from typing import TYPE_CHECKING
+
 from PIL import Image, ImageDraw
 from matrix.modes.mode import BaseMode, ChangeMode, ModeType
 from matrix.resources.fonts import font, bigfont
-from matrix.utils.hardware import Hardware
+
+if TYPE_CHECKING:
+    from matrix.utils.hardware import Hardware
 
 
 BRIGHTNESS_STEP = 10
 
 
 class Brightness(BaseMode):
-    def __init__(self, change_mode: ChangeMode, *, hardware: Hardware):
+    def __init__(self, change_mode: ChangeMode, *, hardware: "Hardware | None"):
         super().__init__(change_mode)
-        self.matrix = hardware.matrix
+        if hardware:
+            self.matrix = hardware.matrix
+        else:
+            self.matrix = None
 
     def handle_encoder_push(self):
         self.change_mode(ModeType.MAIN)
@@ -42,6 +49,8 @@ class Brightness(BaseMode):
         )
 
         draw.rectangle((1, 32, 62, 40), outline="#ffffff")
-        draw.rectangle((1, 32, 1 + int(61 * self.matrix.brightness / 100), 40), fill="#ffffff")
+        draw.rectangle(
+            (1, 32, 1 + int(61 * self.matrix.brightness / 100), 40), fill="#ffffff"
+        )
 
         return image

--- a/matrix/modes/menu.py
+++ b/matrix/modes/menu.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from PIL import Image, ImageDraw
 from matrix.resources.fonts import font
 from matrix.modes.mode import BaseMode, ChangeMode, ModeType
+import sys
 
 
 @dataclass
@@ -19,8 +20,11 @@ class Menu(BaseMode):
             MenuOption("Screen Off", ModeType.OFF),
             MenuOption("Brightness", ModeType.BRIGHTNESS),
             MenuOption("Screens", ModeType.SCREENS),
-            MenuOption("Network", ModeType.NETWORK),
         ]
+
+        if sys.platform == "linux":
+            self.options.append(MenuOption("Network", ModeType.NETWORK))
+
         self.selected_option: int = 0  # which option is selected
 
     def handle_encoder_push(self):

--- a/matrix/screens/screen.py
+++ b/matrix/screens/screen.py
@@ -17,7 +17,7 @@ T = TypeVar("T")
 
 
 class Screen(ABC, Generic[T]):
-    def __init__(self):
+    def __init__(self) -> None:
         self.cached_data: T
 
         self.has_data = threading.Event()
@@ -28,18 +28,18 @@ class Screen(ABC, Generic[T]):
 
         self.is_enabled = True
 
-    def cancel(self):
+    def cancel(self) -> None:
         self.cancel_timer.set()
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.cancel()
 
     @property
-    def is_active(self):
+    def is_active(self) -> bool:
         """Return if the screen should be displayed"""
         return self.is_enabled
 
-    def background_fetcher(self):
+    def background_fetcher(self) -> None:
         while True:
             try:
                 t0 = time.time()
@@ -61,7 +61,7 @@ class Screen(ABC, Generic[T]):
         """Fetch the latest data for this screen."""
 
     @property
-    def data(self):
+    def data(self) -> T:
         """Return the latest cached data."""
         self.has_data.wait()
         return self.cached_data

--- a/matrix/web_ui.py
+++ b/matrix/web_ui.py
@@ -14,6 +14,8 @@ serving._log_add_style = False
 class WebUI:
     def __init__(
         self,
+        *,
+        port: int,
         on_rotation_clockwise: Callable[[], None],
         on_rotation_counterclockwise: Callable[[], None],
         on_press: Callable[[], None],
@@ -25,7 +27,11 @@ class WebUI:
 
         @self.app.route("/")
         def index():
-            logger.info("New connection from %s via '%s'", request.remote_addr, request.user_agent)
+            logger.info(
+                "New connection from %s via '%s'",
+                request.remote_addr,
+                request.user_agent,
+            )
             return render_template("index.html")
 
         @self.app.route("/preview")
@@ -61,11 +67,11 @@ class WebUI:
             on_press()
             return "", 204
 
-        self.thread = threading.Thread(target=self.run)
+        self.thread = threading.Thread(target=self.run, args=(port,))
         self.thread.start()
 
-    def run(self) -> None:
-        self.app.run("0.0.0.0", 80)
+    def run(self, port: int) -> None:
+        self.app.run("0.0.0.0", port)
 
     def send_frame(self, pil_frame: Image.Image) -> None:
         image_bytes = io.BytesIO()


### PR DESCRIPTION
Implement a simulation mode which:

- Skips instantiating a `Hardware` implementation
- Disables Datadog integration
- Changes the web UI port from 80 to 8080

Additionally, removes the Network menu option and mode when running on platforms other than Linux.