### PR TITLE
Retries on HTTPS requests

### DIFF
--- a/matrix/screens/bluebikes.py
+++ b/matrix/screens/bluebikes.py
@@ -6,7 +6,7 @@ import requests
 from PIL import Image, ImageDraw
 
 from matrix.resources.fonts import font, smallfont
-from matrix.screens.screen import REQUEST_DEFAULT_TIMEOUT, Screen
+from matrix.screens.screen import Screen
 
 
 class BlueBikes(Screen[tuple[Any, Any] | None]):
@@ -15,14 +15,12 @@ class BlueBikes(Screen[tuple[Any, Any] | None]):
     def fetch_data(self):
         with ThreadPoolExecutor() as tpe:
             all_stations_future = tpe.submit(
-                requests.get,
+                self.fetch_url,
                 "https://gbfs.lyft.com/gbfs/1.1/bos/en/station_information.json",
-                timeout=REQUEST_DEFAULT_TIMEOUT,
             )
             all_statuses_future = tpe.submit(
-                requests.get,
+                self.fetch_url,
                 "https://gbfs.lyft.com/gbfs/1.1/bos/en/station_status.json",
-                timeout=REQUEST_DEFAULT_TIMEOUT,
             )
 
         return all_stations_future.result().json(), all_statuses_future.result().json()
@@ -49,7 +47,9 @@ class BlueBikes(Screen[tuple[Any, Any] | None]):
             time_str = datetime.datetime.now().strftime("%H:%M")
 
             for i, sta_id in enumerate(STATIONS):
-                draw.text((1, 10 + 18 * i), text=STATIONS[sta_id], font=font, fill="#999999")
+                draw.text(
+                    (1, 10 + 18 * i), text=STATIONS[sta_id], font=font, fill="#999999"
+                )
                 image.paste(Image.open("icons/bike.png"), (1, 18 + 18 * i))
                 draw.text((12, 19 + 18 * i), text="??", font=font, fill="#2CA3E1")
                 image.paste(Image.open("icons/ebike.png"), (25, 18 + 18 * i))
@@ -63,16 +63,24 @@ class BlueBikes(Screen[tuple[Any, Any] | None]):
 
         guids = {}
         for sta_id in STATIONS:
-            sta_info = next(s for s in all_stations["data"]["stations"] if s["short_name"] == sta_id)
+            sta_info = next(
+                s for s in all_stations["data"]["stations"] if s["short_name"] == sta_id
+            )
             guids[sta_id] = sta_info["station_id"]
 
         status = {}
         for sta_id in STATIONS:
-            sta_status = next(s for s in all_status["data"]["stations"] if s["station_id"] == guids[sta_id])
+            sta_status = next(
+                s
+                for s in all_status["data"]["stations"]
+                if s["station_id"] == guids[sta_id]
+            )
             status[sta_id] = sta_status
 
         for i, (sta_id, info) in enumerate(status.items()):
-            draw.text((1, 10 + 18 * i), text=STATIONS[sta_id], font=font, fill="#999999")
+            draw.text(
+                (1, 10 + 18 * i), text=STATIONS[sta_id], font=font, fill="#999999"
+            )
             image.paste(Image.open("icons/bike.png"), (1, 18 + 18 * i))
             draw.text(
                 (12, 19 + 18 * i),
@@ -109,7 +117,9 @@ class BlueBikes(Screen[tuple[Any, Any] | None]):
 
         if self.data is None:
             for i, sta_id in enumerate(STATIONS):
-                draw.text((1, 1 + 16 * i), text=STATIONS[sta_id], font=font, fill="#999999")
+                draw.text(
+                    (1, 1 + 16 * i), text=STATIONS[sta_id], font=font, fill="#999999"
+                )
                 image.paste(Image.open("icons/bike.png"), (1, 8 + 16 * i))
                 draw.text((12, 9 + 16 * i), text="??", font=font, fill="#2CA3E1")
                 image.paste(Image.open("icons/ebike.png"), (25, 8 + 16 * i))
@@ -123,16 +133,24 @@ class BlueBikes(Screen[tuple[Any, Any] | None]):
 
         guids = {}
         for sta_id in STATIONS:
-            sta_info = next(s for s in all_stations["data"]["stations"] if s["short_name"] == sta_id)
+            sta_info = next(
+                s for s in all_stations["data"]["stations"] if s["short_name"] == sta_id
+            )
             guids[sta_id] = sta_info["station_id"]
 
         status = {}
         for sta_id in STATIONS:
-            sta_status = next(s for s in all_status["data"]["stations"] if s["station_id"] == guids[sta_id])
+            sta_status = next(
+                s
+                for s in all_status["data"]["stations"]
+                if s["station_id"] == guids[sta_id]
+            )
             status[sta_id] = sta_status
 
         for i, (sta_id, info) in enumerate(status.items()):
-            draw.text((1, 1 + 16 * i), text=STATIONS[sta_id], font=smallfont, fill="#999999")
+            draw.text(
+                (1, 1 + 16 * i), text=STATIONS[sta_id], font=smallfont, fill="#999999"
+            )
             image.paste(Image.open("icons/bike.png"), (1, 8 + 16 * i))
             draw.text(
                 (12, 9 + 16 * i),

--- a/matrix/screens/fish.py
+++ b/matrix/screens/fish.py
@@ -4,16 +4,15 @@ import requests
 from PIL import Image, ImageDraw
 
 from matrix.resources.fonts import font
-from matrix.screens.screen import REQUEST_DEFAULT_TIMEOUT, Screen
+from matrix.screens.screen import Screen
 
 
 class MakeAFish(Screen[tuple[Image.Image, Image.Image]]):
     CACHE_TTL = 5
 
     def fetch_data(self):
-        data = requests.get(
+        data = self.fetch_url(
             "http://makea.fish/fishimg.php?s=11&t=x6362x&f=11",
-            timeout=REQUEST_DEFAULT_TIMEOUT,
         ).content
         fish = Image.open(io.BytesIO(data))
 

--- a/matrix/screens/forecast.py
+++ b/matrix/screens/forecast.py
@@ -6,7 +6,7 @@ import requests
 from PIL import Image, ImageDraw
 
 from matrix.resources.fonts import font
-from matrix.screens.screen import REQUEST_DEFAULT_TIMEOUT, Screen
+from matrix.screens.screen import Screen
 from matrix.screens.weather import (
     HIGH_COLOR,
     LOW_COLOR,
@@ -31,7 +31,7 @@ class ForecastData(TypedDict):
 
 
 class Forecast(Screen[ForecastData | None]):
-    CACHE_TTL = 600
+    CACHE_TTL = 1200
 
     def fetch_data(self):
         lat = self.config["latitude"]
@@ -47,7 +47,7 @@ class Forecast(Screen[ForecastData | None]):
             "&timezone=auto"
         )
 
-        return requests.get(url, timeout=REQUEST_DEFAULT_TIMEOUT).json()
+        return self.fetch_url(url).json()
 
     def fallback_data(self):
         return None

--- a/matrix/screens/mbta.py
+++ b/matrix/screens/mbta.py
@@ -9,7 +9,7 @@ import requests
 from PIL import Image, ImageDraw
 
 from matrix.resources.fonts import font, smallfont
-from matrix.screens.screen import REQUEST_DEFAULT_TIMEOUT, Screen
+from matrix.screens.screen import Screen
 
 PredictionType: TypeAlias = Literal["prediction", "schedule"]
 
@@ -32,8 +32,10 @@ class Prediction:
     type: PredictionType
 
 
-def get_predictions(line: Line, api_key: str) -> list[Prediction]:
-    predictions_response = requests.get(
+def get_predictions(
+    session: requests.Session, line: Line, api_key: str
+) -> list[Prediction]:
+    predictions_response = session.get(
         "https://api-v3.mbta.com/predictions",
         params={
             "filter[stop]": line.stop_id,
@@ -44,7 +46,7 @@ def get_predictions(line: Line, api_key: str) -> list[Prediction]:
             "page[limit]": "10",
             "api_key": api_key,
         },
-        timeout=REQUEST_DEFAULT_TIMEOUT,
+        timeout=15,
     )
 
     predictions_response.raise_for_status()
@@ -104,7 +106,7 @@ def get_predictions(line: Line, api_key: str) -> list[Prediction]:
         service_hour = wall_time.hour
         service_minute = wall_time.minute
 
-    schedule_response = requests.get(
+    schedule_response = session.get(
         "https://api-v3.mbta.com/schedules",
         params={
             "filter[stop]": line.stop_id,
@@ -118,7 +120,7 @@ def get_predictions(line: Line, api_key: str) -> list[Prediction]:
             "filter[max_time]": f"{service_hour + 2:02}:{service_minute:02}",
             "api_key": api_key,
         },
-        timeout=REQUEST_DEFAULT_TIMEOUT,
+        timeout=15,
     )
 
     schedule_response.raise_for_status()
@@ -152,15 +154,15 @@ def get_predictions(line: Line, api_key: str) -> list[Prediction]:
     return results
 
 
-def get_alert(line: Line, api_key: str) -> str | None:
-    response = requests.get(
+def get_alert(session: requests.Session, line: Line, api_key: str) -> str | None:
+    response = session.get(
         "https://api-v3.mbta.com/alerts",
         params={
             "filter[route]": line.route_id,
             "filter[datetime]": "NOW",
             "api_key": api_key,
         },
-        timeout=REQUEST_DEFAULT_TIMEOUT,
+        timeout=15,
     )
 
     response.raise_for_status()
@@ -246,7 +248,7 @@ class MBTA(Screen[MbtaData]):
             predictions = [
                 prediction
                 for line_predictions in tpe.map(
-                    lambda line: get_predictions(line, api_key),
+                    lambda line: get_predictions(self.session, line, api_key),
                     self.lines,
                 )
                 for prediction in line_predictions
@@ -256,7 +258,7 @@ class MBTA(Screen[MbtaData]):
         alert = None
         alert_line = None
         for line in self.lines[:2]:
-            alert = get_alert(line, api_key)
+            alert = get_alert(self.session, line, api_key)
             if alert is not None:
                 alert_line = line
                 break
@@ -300,14 +302,18 @@ class MBTA(Screen[MbtaData]):
 
             draw.text((3, 11 + 19 * row), line.symbol, font=smallfont, fill=line.color)
 
-            draw.text((6 + length, 10 + 19 * row), line.headsign, font=font, fill=line.color)
+            draw.text(
+                (6 + length, 10 + 19 * row), line.headsign, font=font, fill=line.color
+            )
             line_predictions = filter(lambda p: p.line == line, predictions)
 
             pixel_x = 2
             for prediction in line_predictions:
                 time_str = str(int(prediction.eta / timedelta(minutes=1)))
                 length = draw.textlength(time_str, font=font)
-                if pixel_x + length > 64 - (draw.textlength("min", font=font) + X_MARGIN):
+                if pixel_x + length > 64 - (
+                    draw.textlength("min", font=font) + X_MARGIN
+                ):
                     break
 
                 draw.text(
@@ -334,7 +340,9 @@ class MBTA(Screen[MbtaData]):
 
             draw.line((9, 47, 60, 47), fill="#888888")
 
-            draw.text((12, 50), f"{alert_line.label} Alert", font=smallfont, fill="#888888")
+            draw.text(
+                (12, 50), f"{alert_line.label} Alert", font=smallfont, fill="#888888"
+            )
 
             draw.text((1 - self.scroll_idx, 57), alert_text, font=font, fill="#ff0000")
             draw.text(
@@ -388,7 +396,9 @@ class MBTA(Screen[MbtaData]):
             for prediction in line_predictions:
                 time_str = str(int(prediction.eta / timedelta(minutes=1)))
                 length = draw.textlength(time_str, font=font)
-                if pixel_x + length > 64 - (draw.textlength("min", font=font) + X_MARGIN):
+                if pixel_x + length > 64 - (
+                    draw.textlength("min", font=font) + X_MARGIN
+                ):
                     break
 
                 draw.text(

--- a/matrix/screens/octoprint.py
+++ b/matrix/screens/octoprint.py
@@ -20,7 +20,7 @@ class Octoprint(Screen[dict]):
         super().__init__(config, size)
 
     def _get(self, path: str):
-        return requests.get(
+        return self.session.get(
             urljoin(self.endpoint, path),
             headers={"Authorization": f"Bearer {self.api_key}"},
         ).json()

--- a/matrix/screens/screen.py
+++ b/matrix/screens/screen.py
@@ -3,6 +3,8 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
+import requests
+from requests.adapters import HTTPAdapter, Retry
 
 from datadog.dogstatsd.base import statsd
 
@@ -10,7 +12,6 @@ from matrix.utils.panels import Drawable, PanelSize
 
 logger = logging.getLogger(__name__)
 
-REQUEST_DEFAULT_TIMEOUT = 15
 CACHE_TTL = 60
 
 T = TypeVar("T")
@@ -21,6 +22,13 @@ class Screen(ABC, Drawable, Generic[T]):
         self.config = config
         self.size = size
         self.cached_data: T
+
+        retries = Retry(
+            total=5, backoff_factor=0.1, status_forcelist=[500, 502, 503, 504]
+        )
+
+        self.session = requests.Session()
+        self.session.mount("https://", HTTPAdapter(max_retries=retries))
 
         self.has_data = threading.Event()
         self.cancel_timer = threading.Event()
@@ -40,6 +48,9 @@ class Screen(ABC, Drawable, Generic[T]):
     def is_active(self) -> bool:
         """Return if the screen should be displayed"""
         return self.is_enabled
+
+    def fetch_url(self, url: str) -> requests.Response:
+        return self.session.get(url, timeout=15)
 
     def background_fetcher(self) -> None:
         while True:

--- a/matrix/screens/spotify.py
+++ b/matrix/screens/spotify.py
@@ -5,7 +5,7 @@ import spotipy
 from PIL import Image
 from spotipy.oauth2 import SpotifyOAuth
 
-from matrix.screens.screen import REQUEST_DEFAULT_TIMEOUT, Screen
+from matrix.screens.screen import Screen
 
 scope = "user-read-currently-playing user-read-playback-state"
 
@@ -33,7 +33,7 @@ class Spotify(Screen[Image.Image | None]):
             state = sp.current_user_playing_track()
             if state and state["item"]:
                 cover_url = state["item"]["album"]["images"][0]["url"]
-                image_data = requests.get(cover_url, timeout=REQUEST_DEFAULT_TIMEOUT).content
+                image_data = self.fetch_url(cover_url).content
                 return Image.open(io.BytesIO(image_data)).resize((64, 64))
 
         return None
@@ -42,18 +42,20 @@ class Spotify(Screen[Image.Image | None]):
         return None
 
     def get_image_64x64(self):
+        image = Image.new("RGB", (64, 64))
+
         if data := self.data:
-            image = Image.new("RGB", (64, 64))
             image.paste(data)
-            return image
-        return None
+
+        return image
 
     def get_image_64x32(self):
+        image = Image.new("RGB", (64, 32))
+
         if data := self.data:
-            image = Image.new("RGB", (64, 32))
             image.paste(data.resize((32, 32)), (16, 0))
-            return image
-        return None
+
+        return image
 
     @property
     def is_active(self):

--- a/matrix/screens/weather.py
+++ b/matrix/screens/weather.py
@@ -6,7 +6,7 @@ import requests
 from PIL import Image, ImageDraw
 
 from matrix.resources.fonts import bigfont, font
-from matrix.screens.screen import REQUEST_DEFAULT_TIMEOUT, Screen
+from matrix.screens.screen import Screen
 
 TIME_DATE_COLOR = "#aaaaaa"
 HIGH_COLOR = "#ffa024"
@@ -83,7 +83,7 @@ class Weather(Screen[WeatherData | None]):
             "&timezone=auto"
         )
 
-        return requests.get(url, timeout=REQUEST_DEFAULT_TIMEOUT).json()
+        return self.fetch_url(url).json()
 
     def fallback_data(self):
         return None


### PR DESCRIPTION
Most of the apparent errors (missing train data, blank forecast, etc) seem to come from transient web request errors.

We can use an `HTTPAdapter` to enforce a retry policy with backoff for all screen types.

Stacked on #11 and #12.